### PR TITLE
Allow all valid port numbers

### DIFF
--- a/libs/configs.js
+++ b/libs/configs.js
@@ -28,7 +28,7 @@ class configs {
         if(typeof this.port !== 'number' || this.port < 1 || this.port > 65536) {
             return {
                 valid: false,
-                details: 'port is a number and must be within 1025 to 65536'
+                details: 'port is a number and must be within 1 to 65536'
             };
         }
         if(this.apiVersion !== 'v1' && this.apiVersion !== 'v2') {

--- a/libs/configs.js
+++ b/libs/configs.js
@@ -25,7 +25,7 @@ class configs {
                 details: 'host must be an IP address or fully qualified domain name'
             };
         }
-        if(typeof this.port !== 'number' || this.port < 1025 || this.port > 65536) {
+        if(typeof this.port !== 'number' || this.port < 1 || this.port > 65536) {
             return {
                 valid: false,
                 details: 'port is a number and must be within 1025 to 65536'

--- a/test/configs.test.js
+++ b/test/configs.test.js
@@ -53,7 +53,7 @@ describe('Testing  Configuration files', () => {
         let myConfigs = new configsObject(inValidTestConfigs(2));
         let validated = myConfigs.validateConfigs();
         expect(validated.valid).toBe(false);
-        expect(validated.details).toEqual('port is a number and must be within 1025 to 65536');
+        expect(validated.details).toEqual('port is a number and must be within 1 to 65536');
     });
 
     it('4.4) configs validate must check the type of values of configs entered by the user, apiVersion part', () => {


### PR DESCRIPTION
I've seen many Vault installations that run over HTTPS (port 443). This package would be even more useful if it allowed all possible ports, not just the non-root ports.

* Relaxes port number check to be all valid ports