### PR TITLE
Fix Typo In README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can use below code to login to vault server from Lambda, by default vault ap
 const vaultAuthClient = require('vault-auth-aws');
 let vaultClient = new vaultAwsAuth({host: 'vault.example.com'});
 vaultClient.authenticate()
-        .then((sucess) => {
+        .then((success) => {
                 const vault = require('node-vault')({
                 apiVersion: config.apiVersion,
                 endpoint: config.endpoint,


### PR DESCRIPTION
I guess you didn't copy the example from working code, lol.

In good news, it worked great after I tuned up that! My only other comment would be that the "vaultAppName" part of the config seemed to be a confusing name. The value I needed to pass there had nothing to do with my function name (which is passed as default), and instead was aligned with the name of the Vault role name I'm asking to use as the IAM user.