### PR TITLE
AWS credential support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const AWS = require('aws-sdk');
 const configsClass = require('./libs/configs');
 const awsSignedCongifs = require('./libs/awsSignedConfigs');
 const request = require('request');
@@ -18,7 +19,7 @@ class vaultAwsAuth {
         let options = {
             url: this.configs.uri,
             followAllRedirects: this.configs.followAllRedirects,
-            body: JSON.stringify(awsLoginConfigs.getSignedConfigs())
+            body: JSON.stringify(awsLoginConfigs.getSignedConfigs(creds))
         };
         if(this.configs.sslCertificate) {
             options['cert'] = this.configs.sslCertificate;
@@ -30,18 +31,21 @@ class vaultAwsAuth {
     }
 
     authenticate () {
-        return new Promise((resolve, reject) => {
-            let options = this.getOptions();
-            request.post(options, function (err, res, body) {
-                if(err)
-                    reject(err);
-                else {
-                    let result = JSON.parse(body);
-                    if(result.errors)
+        const providerChain = new AWS.CredentialProviderChain();
+        return providerChain.resolvePromise().then(creds => {
+            return new Promise((resolve, reject) => {
+                let options = this.getOptions(creds);
+                request.post(options, function (err, res, body) {
+                    if(err)
+                        reject(err);
+                    else {
+                        let result = JSON.parse(body);
+                        if(result.errors)
                         reject(result);
                     else
                         resolve(result);
-                }
+                    }
+                });
             });
         });
     }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class vaultAwsAuth {
         this.configs = configs.getConfigs();
     }
 
-    getOptions () {
+    getOptions (creds) {
         let awsLoginConfigs = new awsSignedCongifs({host:this.configs.host,vaultAppName:this.configs.vaultAppName});
         let options = {
             url: this.configs.uri,

--- a/libs/awsSignedConfigs.js
+++ b/libs/awsSignedConfigs.js
@@ -7,7 +7,15 @@ class awsSignedConfigs {
         this.awsRequestUrl = 'https://sts.amazonaws.com/';
         this.awsRequestBody = 'Action=GetCallerIdentity&Version=2011-06-15';
     }
-    getSignedRequest () {
+    getSignedRequest (creds) {
+        let awsCreds = {
+            accessKeyId: creds.accessKeyId,
+            secretAccessKey: creds.secretAccessKey
+        };
+        if (creds.sessionToken) {
+            awsCreds.sessionToken = creds.sessionToken;
+        }
+
         if(this.vaultHost) {
             var signedRequest = aws4.sign({
                 service: 'sts',
@@ -22,8 +30,8 @@ class awsSignedConfigs {
         return signedRequest;
     }
 
-    getSignedHeaders () {
-        let signedRequest = this.getSignedRequest();
+    getSignedHeaders (creds) {
+        let signedRequest = this.getSignedRequest(creds);
         let headers = signedRequest.headers;
         for (let header in headers) {
             if (typeof headers[header] === 'number') {
@@ -34,8 +42,8 @@ class awsSignedConfigs {
         return headers;
     }
 
-    getSignedConfigs() {
-        let headers = this.getSignedHeaders();
+    getSignedConfigs(creds) {
+        let headers = this.getSignedHeaders(creds);
 
         return {
             role: this.vaultAppName,

--- a/libs/awsSignedConfigs.js
+++ b/libs/awsSignedConfigs.js
@@ -21,11 +21,11 @@ class awsSignedConfigs {
                 service: 'sts',
                 headers: {'X-Vault-AWS-IAM-Server-ID': this.vaultHost},
                 body: this.awsRequestBody
-            });
+            }, awsCreds);
             
         }
         else {
-           var signedRequest = aws4.sign({service: 'sts', body: this.awsRequestBody});
+           var signedRequest = aws4.sign({service: 'sts', body: this.awsRequestBody}, awsCreds);
         }
         return signedRequest;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-auth-aws",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "js module that get token from vault HashiCorp server by using AWS STS ",
   "main": "index.js",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "test"
   },
   "dependencies": {
+    "aws-sdk": "^2.176.0",
     "aws4": "^1.6.0",
     "request": "^2.81.0",
     "validator": "^8.1.0"

--- a/test/awsSignedConfigs.test.js
+++ b/test/awsSignedConfigs.test.js
@@ -1,16 +1,18 @@
 const awsSignedConfigs = require('./../libs/awsSignedConfigs');
 const validator = require('validator');
 
+let creds = {accessKeyId: '', secretAccessKey: ''};
+
 describe('Testing AWS Signed Configs', () => {
     it('1) aws signed configs must be json object',() => {
         let configs = new awsSignedConfigs(testValidConfig());
         let objectConstructor = {}.constructor;
-        expect(configs.getSignedConfigs().constructor).toEqual(objectConstructor);
+        expect(configs.getSignedConfigs(creds).constructor).toEqual(objectConstructor);
     });
 
     it('2) aws signed configs must include role as string, iam_http_request_method must be POST, iam_request_url must be base64, iam_request_body must be base64 and iam_request_headers must be base64',() => {
         let configs = new awsSignedConfigs(testValidConfig());
-        configs = configs.getSignedConfigs();
+        configs = configs.getSignedConfigs(creds);
         expect(typeof configs['role']).toEqual('string');
         expect(configs['iam_http_request_method']).toEqual('POST');
         expect(validator.isBase64(configs['iam_request_url'])).toBe(true);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,15 +1,18 @@
 const index = require('./../index');
+
+let creds = {accessKeyId: '', secretAccessKey: ''};
+
 describe('Testing index file functions', () => {
     it('1) options must be json', () => {
         let vaultAuth = new index(configs(0));
-        let options = vaultAuth.getOptions();
+        let options = vaultAuth.getOptions(creds);
         let objectConstructor = {}.constructor;
         expect(options.constructor).toEqual(objectConstructor);
     });
 
     it('2) options must include at least url, followAllRedirects and body', () => {
         let vaultAuth = new index(configs(0));
-        let options = vaultAuth.getOptions();
+        let options = vaultAuth.getOptions(creds);
         expect(typeof options['url']).toEqual('string');
         expect(typeof options['followAllRedirects']).toEqual('boolean');
         expect(typeof options['body']).toEqual('string');
@@ -17,7 +20,7 @@ describe('Testing index file functions', () => {
 
     it('3) if certFilePath was there then options must include cert', () => {
         let vaultAuth = new index(configs(1));
-        let options = vaultAuth.getOptions();
+        let options = vaultAuth.getOptions(creds);
         expect(typeof options['url']).toEqual('string');
         expect(typeof options['followAllRedirects']).toEqual('boolean');
         expect(typeof options['body']).toEqual('string');
@@ -26,7 +29,7 @@ describe('Testing index file functions', () => {
 
     it('4) if sslRejectUnAuthorized was false then NODE_TLS_REJECT_UNAUTHORIZED must be 0', () => {
         let vaultAuth = new index(configs(2));
-        let options = vaultAuth.getOptions();
+        let options = vaultAuth.getOptions(creds);
         expect(process.env['NODE_TLS_REJECT_UNAUTHORIZED']).toEqual('0');
     });
 });


### PR DESCRIPTION
Use the `aws-sdk` to fetch credentials for vault auth. The module used for signing, `aws4`, uses environment variables by default. This PR uses the default `AWS.CredentialProviderChain` to fetch credentials. The default provider chain uses environment variables by default ([AWS JS docs reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html#defaultProviders-property)).

Existing functionality should continue to work as before (environment variables for access keys and secrets are used by default). However, this will allow applications to use other authentication mechanisms, including the EC2 metadata service. Additionally, ECS applications can retrieve application-specific credentials associated with their roles.