### PR TITLE
add X-Vault-Namespace to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A module for authenticating against Vault server by HashiCorp when running as AW
 ### Prerequisites
 Uses AWS SDK v3.
 
-### install 
+### install
 `npm install vault-auth-aws`
 
 ### Login
@@ -43,6 +43,7 @@ let vaultClient = new VaultAwsAuth({ host: 'vault.example.com', vaultAppName: 'm
 - apiVersion: vault server API endpoint version, default is v1.
 - vaultLoginUrl: Vault login URL, default is auth/aws/login.
 - vaultAppName: Vault application name, default is lambda name if any.
+- vaultNamespace: Vault namespace to use, default is blank. Can also be set using VAULT_NAMESPACE environment variable. See [Vault Namespaces](https://www.vaultproject.io/docs/enterprise/namespaces/index.html) for more information.
 - followAllRedirects: accepts boolean, by default is true.
 - certFilePath: path for a certificate that might be needed by the server.
 - sslRejectUnAuthorized: accepts boolean, specified once the certificate is self-signed and cannot be verified, default is true.

--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ class VaultAwsAuth {
         if(!this.configs.sslRejectUnAuthorized) {
             process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
         }
+        if (this.configs.vaultNamespace) {
+            options.headers = {
+                "X-Vault-Namespace": this.configs.vaultNamespace,
+            };
+        }
         return options;
     }
 

--- a/libs/configs.js
+++ b/libs/configs.js
@@ -9,6 +9,7 @@ class Configs {
         this.apiVersion = args.apiVersion || 'v1';
         this.vaultLoginUrl = args.vaultLoginUrl || 'auth/aws/login';
         this.vaultAppName = args.vaultAppName || process.env.AWS_LAMBDA_FUNCTION_NAME;
+        this.vaultNamespace = args.vaultNamespace || process.env.VAULT_NAMESPACE;
         this.followAllRedirects = args.followAllRedirects || true;
         this.certFilePath = args.certFilePath;
         this.sslRejectUnAuthorized = args.sslRejectUnAuthorized === undefined || args.sslRejectUnAuthorized === true;
@@ -49,6 +50,12 @@ class Configs {
                 details: 'vaultAppName must be string'
             };
         }
+        if (this.vaultNamespace && typeof this.vaultNamespace !== "string") {
+          return {
+            valid: false,
+            details: "vaultNamespace must be string",
+          };
+        }
         if(typeof this.followAllRedirects !== 'boolean') {
             return {
                 valid: false,
@@ -69,6 +76,7 @@ class Configs {
             apiVersion: this.apiVersion,
             vaultLoginUrl: this.vaultLoginUrl,
             vaultAppName: this.vaultAppName,
+            vaultNamespace: this.vaultNamespace,
             uri: this.uri,
             followAllRedirects: this.followAllRedirects,
             sslRejectUnAuthorized: this.sslRejectUnAuthorized

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vault-auth-aws",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vault-auth-aws",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/credential-provider-node": "^3.95.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-auth-aws",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "js module that get token from vault HashiCorp server by using AWS STS ",
   "author": "Abdullah Shahin <eng.abd.shahin@gmail.com>",
   "license": "ISC",


### PR DESCRIPTION
This adds the `X-Vault-Namespace` as a config option. I believe this is the recommended approach by Hashicorp now when authenticating with AWS. This may be a caveat with our vault cluster, but after adding this header to our auth login request, everything works.

Referenced docs for hashicorp vault when setting up vault auth method for AWS:

https://learn.hashicorp.com/tutorials/cloud/vault-auth-method-aws?in=vault/cloud-ops

<img width="935" alt="image" src="https://user-images.githubusercontent.com/95193764/194428531-b58b4c33-1402-456d-a7b4-f1c1bb0a7b64.png">
